### PR TITLE
First version of the new error system. Include tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,30 @@ To call one of those use cases you will need to provide the name in your call:
 
 ###Error handling
 
-#~TODO Explain how errors are treated once its redesigned~
+Errors can be either manually reported or implicitly notified when an exception is thrown from your use case context. To handle errors, there is a capturing event system that iterates over all your registered ``OnErrorCallback`` implementations and notifies them of the issue. Every callback needs to return a boolean value to inform whether the error has been handled and needs no further management. Callbacks are always called in specific order:
+
+1. Use case specific callback; the ones you register before calling a use case.
+2. Global callbacks; the ones you can register from your presenter constructor.
+
+With this approach you can create an error callback in your presenter that shows a generic error message to your user and create multiple other listeners for specific use cases and/or errors.
+
+To register global callbacks from your presenter, call ``registerOnErrorCallback`` in the constructor:
+
+```java
+public class SamplePresenter extends RosiePresenter<SamplePresenter.View> implements OnErrorCallback {
+	public SamplePresenter(UseCaseHandler useCaseHandler) {
+		super(useCaseHandler);
+		registerOnErrorCallback(this);
+	}
+
+	@Override public boolean onError(Error error) {
+		getView().showGenericError();
+		return true;
+	}
+}
+```
+
+#~TODO Example of registering an error listener in a use case~
 
 ###Repository
 

--- a/rosie/src/main/java/com/karumi/rosie/domain/usecase/RosieUseCase.java
+++ b/rosie/src/main/java/com/karumi/rosie/domain/usecase/RosieUseCase.java
@@ -74,24 +74,7 @@ public class RosieUseCase {
    */
 
   protected void notifyError(final Error error) throws ErrorNotHandledException {
-    if (onErrorCallback == null) {
-      throw new ErrorNotHandledException(error);
-    }
-
-    final OnErrorCallback callback = this.onErrorCallback.get();
-    if (callback != null) {
-      try {
-        getCallbackScheduler().post(new Runnable() {
-          @Override public void run() {
-            callback.onError(error);
-          }
-        });
-      } catch (IllegalArgumentException e) {
-        throw new ErrorNotHandledException(error);
-      }
-    } else {
-      throw new ErrorNotHandledException(error);
-    }
+    onErrorCallback.get().onError(error);
   }
 
   /**

--- a/rosie/src/main/java/com/karumi/rosie/domain/usecase/UseCaseWrapper.java
+++ b/rosie/src/main/java/com/karumi/rosie/domain/usecase/UseCaseWrapper.java
@@ -38,13 +38,13 @@ public final class UseCaseWrapper {
       Method methodToInvoke = UseCaseFilter.filter(useCase, useCaseParams);
       methodToInvoke.invoke(useCase, useCaseParams.getArgs());
     } catch (Exception e) {
-      notifyError(e);
+      notifyException(e);
     }
   }
 
-  private void notifyError(Exception exception) {
+  private void notifyException(Exception exception) {
     if (errorHandler != null) {
-      errorHandler.notifyError(exception, useCaseParams.getOnErrorCallback());
+      errorHandler.notifyException(exception, useCaseParams.getOnErrorCallback());
     }
   }
 }

--- a/rosie/src/main/java/com/karumi/rosie/domain/usecase/error/OnErrorCallback.java
+++ b/rosie/src/main/java/com/karumi/rosie/domain/usecase/error/OnErrorCallback.java
@@ -20,6 +20,13 @@ package com.karumi.rosie.domain.usecase.error;
  * Callback invoked when an error happens inside of a use case.
  */
 public interface OnErrorCallback<T extends Error> {
-  void onError(T error);
+  /**
+   * Method called when an error has occurred while executing a use case.
+   *
+   * @param error Error thrown by the use case
+   * @return true if the error has been consumed, meaning it won't be notified to
+   * other registered callbacks
+   */
+  boolean onError(T error);
 }
 

--- a/rosie/src/test/java/com/karumi/rosie/domain/usecase/UseCaseHandlerTest.java
+++ b/rosie/src/test/java/com/karumi/rosie/domain/usecase/UseCaseHandlerTest.java
@@ -21,7 +21,6 @@ import com.karumi.rosie.domain.usecase.annotation.Success;
 import com.karumi.rosie.domain.usecase.annotation.UseCase;
 import com.karumi.rosie.domain.usecase.callback.OnSuccessCallback;
 import com.karumi.rosie.domain.usecase.error.ErrorHandler;
-import com.karumi.rosie.domain.usecase.error.ErrorNotHandledException;
 import com.karumi.rosie.domain.usecase.error.OnErrorCallback;
 import com.karumi.rosie.doubles.FakeCallbackScheduler;
 import com.karumi.rosie.doubles.NetworkError;
@@ -193,7 +192,7 @@ public class UseCaseHandlerTest extends UnitTest {
     assertNotNull(onSuccessCallback.getValue());
   }
 
-  @Test public void completeCallbackShouldNotBeExecuteWhenNotMatchArgs() {
+  @Test public void completeCallbackShouldNotBeExecutedWhenNotMatchArgs() {
     FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
     AnyUseCase anyUseCase = new AnyUseCase();
     EmptyOnSuccess onSuccessCallback = new EmptyOnSuccess();
@@ -236,7 +235,7 @@ public class UseCaseHandlerTest extends UnitTest {
     verify(errorCallback).onError(any(Error.class));
   }
 
-  @Test public void shouldCallErrorHandlerWhenUseCaseInvokeAnErrorAndDontExistSpecificCallback() {
+  @Test public void shouldCallErrorHandlerWhenUseCaseInvokeAnError() {
     FakeTaskScheduler taskScheduler = new FakeTaskScheduler();
     ErrorUseCase errorUseCase = new ErrorUseCase();
     ErrorHandler errorHandler = mock(ErrorHandler.class);
@@ -245,8 +244,7 @@ public class UseCaseHandlerTest extends UnitTest {
 
     useCaseHandler.execute(errorUseCase, useCaseParams);
 
-    verify(errorHandler).notifyError(any(ErrorNotHandledException.class),
-        eq((OnErrorCallback) null));
+    verify(errorHandler).notifyError(any(Error.class), eq((OnErrorCallback) null));
   }
 
   @Test public void shouldNotifyErrorHandlerWhenUseCaseOnErrorCallbackDoesNotExist() {
@@ -260,8 +258,7 @@ public class UseCaseHandlerTest extends UnitTest {
 
     useCaseHandler.execute(errorUseCase, useCaseParams);
 
-    verify(errorHandler).notifyError(any(ErrorNotHandledException.class),
-        eq(specificErrorCallback));
+    verify(errorHandler).notifyError(any(Error.class), eq(specificErrorCallback));
   }
 
   @Test public void shouldCallErrorHandlerErrorWhenUseCaseThrowsAnException() {
@@ -274,7 +271,7 @@ public class UseCaseHandlerTest extends UnitTest {
 
     useCaseHandler.execute(errorUseCase, useCaseParams);
 
-    verify(errorHandler).notifyError(any(Exception.class), eq((OnErrorCallback) null));
+    verify(errorHandler).notifyException(any(Exception.class), eq((OnErrorCallback) null));
   }
 
   @Test public void shouldThrowExceptionIfUseCaseNotifiesSuccessButThereIsNoOnSuccessCallback() {
@@ -286,7 +283,8 @@ public class UseCaseHandlerTest extends UnitTest {
 
     useCaseHandler.execute(successUseCase, useCaseParams);
 
-    verify(errorHandler).notifyError(any(IllegalStateException.class), eq((OnErrorCallback) null));
+    verify(errorHandler).notifyException(any(IllegalStateException.class),
+        eq((OnErrorCallback) null));
   }
 
   @Test public void shouldThrowExceptionIfTheOnSuccessCallbackHasNoMethodsWithSuccessAnnotations() {
@@ -299,7 +297,8 @@ public class UseCaseHandlerTest extends UnitTest {
 
     useCaseHandler.execute(successUseCase, useCaseParams);
 
-    verify(errorHandler).notifyError(any(IllegalStateException.class), eq((OnErrorCallback) null));
+    verify(errorHandler).notifyException(any(IllegalStateException.class),
+        eq((OnErrorCallback) null));
   }
 
   @Test public void shouldSupportNullUseCaseParams() {
@@ -317,21 +316,21 @@ public class UseCaseHandlerTest extends UnitTest {
   }
 
   private OnErrorCallback onErrorCallback = new OnErrorCallback<Error>() {
-
-    @Override public void onError(Error error) {
+    @Override public boolean onError(Error error) {
+      return false;
     }
   };
 
   private OnErrorCallback specificErrorCallback = new OnErrorCallback<NetworkError>() {
-
-    @Override public void onError(NetworkError error) {
+    @Override public boolean onError(NetworkError error) {
+      return false;
     }
   };
 
   private class AnyOnSuccess implements OnSuccessCallback {
     private int value;
 
-    @Success public void onSucess(int value) {
+    @Success public void onSuccess(int value) {
       this.value = value;
     }
 
@@ -355,7 +354,7 @@ public class UseCaseHandlerTest extends UnitTest {
   private class EmptyOnSuccess implements OnSuccessCallback {
     private boolean success = false;
 
-    @Success public void onSucess() {
+    @Success public void onSuccess() {
       success = true;
     }
 

--- a/rosie/src/test/java/com/karumi/rosie/domain/usecase/UseCaseWrapperTest.java
+++ b/rosie/src/test/java/com/karumi/rosie/domain/usecase/UseCaseWrapperTest.java
@@ -21,9 +21,7 @@ import com.karumi.rosie.domain.usecase.annotation.UseCase;
 import com.karumi.rosie.domain.usecase.error.ErrorHandler;
 import com.karumi.rosie.domain.usecase.error.ErrorNotHandledException;
 import com.karumi.rosie.domain.usecase.error.OnErrorCallback;
-import java.lang.reflect.InvocationTargetException;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -59,27 +57,8 @@ public class UseCaseWrapperTest extends UnitTest {
 
     useCaseWrapper.execute();
 
-    verify(errorHandler).notifyError(any(ErrorNotHandledException.class),
+    verify(errorHandler).notifyException(any(ErrorNotHandledException.class),
         eq((OnErrorCallback) null));
-  }
-
-  @Test public void shouldNotifyErrorUsingTheErrorGeneratedFromTheUseCase() {
-    AnyUseCase anyUseCase = new AnyUseCase();
-    Error error = mock(Error.class);
-    anyUseCase.setErrorToNotify(error);
-    UseCaseParams argsParams =
-        new UseCaseParams.Builder().args(ANY_FIRST_ARG, ANY_SECOND_ARG).build();
-    ErrorHandler errorHandler = mock(ErrorHandler.class);
-    UseCaseWrapper useCaseWrapper = new UseCaseWrapper(anyUseCase, argsParams, errorHandler);
-    ArgumentCaptor<InvocationTargetException> errorArgumentCaptor =
-        ArgumentCaptor.forClass(InvocationTargetException.class);
-
-    useCaseWrapper.execute();
-
-    verify(errorHandler).notifyError(errorArgumentCaptor.capture(), eq((OnErrorCallback) null));
-    ErrorNotHandledException errorNotHandledException =
-        (ErrorNotHandledException) errorArgumentCaptor.getValue().getTargetException();
-    assertEquals(error, errorNotHandledException.getError());
   }
 
   private class AnyUseCase extends RosieUseCase {

--- a/rosie/src/test/java/com/karumi/rosie/doubles/FakePresenter.java
+++ b/rosie/src/test/java/com/karumi/rosie/doubles/FakePresenter.java
@@ -20,19 +20,21 @@ import com.karumi.rosie.domain.usecase.RosieUseCase;
 import com.karumi.rosie.domain.usecase.UseCaseHandler;
 import com.karumi.rosie.domain.usecase.annotation.UseCase;
 import com.karumi.rosie.domain.usecase.error.ErrorHandler;
+import com.karumi.rosie.domain.usecase.error.OnErrorCallback;
 import com.karumi.rosie.testutils.FakeTaskScheduler;
 import com.karumi.rosie.view.RosiePresenter;
 
 /**
  * Double presenter to use on some tests.
  */
-public class FakePresenter extends RosiePresenter {
+public class FakePresenter extends RosiePresenter implements OnErrorCallback {
   private UseCaseHandler useCaseHandler;
   private FakeUi fakeUi;
 
   public FakePresenter() {
     this(
         new UseCaseHandler(new FakeTaskScheduler(), new ErrorHandler(new FakeCallbackScheduler())));
+    registerOnErrorCallback(this);
   }
 
   public FakePresenter(UseCaseHandler useCaseHandler) {
@@ -49,7 +51,7 @@ public class FakePresenter extends RosiePresenter {
     this.fakeUi = fakeUi;
   }
 
-  @Override protected boolean onError(Error error) {
+  @Override public boolean onError(Error error) {
     if (fakeUi != null) {
       fakeUi.showFakeError();
       return true;
@@ -64,7 +66,7 @@ public class FakePresenter extends RosiePresenter {
 
   public class ErrorUseCase extends RosieUseCase {
 
-    @UseCase public void excuteError() throws Exception {
+    @UseCase public void executeError() throws Exception {
       notifyError(new Error("error"));
     }
   }

--- a/rosie/src/test/java/com/karumi/rosie/view/RosiePresenterTest.java
+++ b/rosie/src/test/java/com/karumi/rosie/view/RosiePresenterTest.java
@@ -39,7 +39,7 @@ public class RosiePresenterTest extends UnitTest {
   }
 
   @Test public void shouldExecuteUseCaseUsingTheUseCaseHandler() {
-    RosiePresenter rosiePresenter = givenARosiePresenter();
+    RosiePresenter rosiePresenter = givenARosiePresenterWithRegisteredCallback();
 
     rosiePresenter.execute(anyUseCase);
 
@@ -47,7 +47,7 @@ public class RosiePresenterTest extends UnitTest {
   }
 
   @Test public void shouldExecuteUseCaseWithUseCaseParamsUsingTheUseCaseHandler() {
-    RosiePresenter rosiePresenter = givenARosiePresenter();
+    RosiePresenter rosiePresenter = givenARosiePresenterWithRegisteredCallback();
 
     rosiePresenter.execute(anyUseCase, anyUseCaseParams);
 
@@ -55,7 +55,7 @@ public class RosiePresenterTest extends UnitTest {
   }
 
   @Test public void shouldRegisterGlobalErrorCallbackDuringTheInitializeLifecycleStage() {
-    RosiePresenter rosiePresenter = givenARosiePresenter();
+    RosiePresenter rosiePresenter = givenARosiePresenterWithRegisteredCallback();
 
     rosiePresenter.initialize();
     rosiePresenter.update();
@@ -64,14 +64,26 @@ public class RosiePresenterTest extends UnitTest {
   }
 
   @Test public void shouldUnregisterGlobalErrorCallbackDuringThePauseLifecycleStage() {
-    RosiePresenter rosiePresenter = givenARosiePresenter();
+    RosiePresenter rosiePresenter = givenARosiePresenterWithRegisteredCallback();
 
     rosiePresenter.pause();
 
     verify(useCaseHandler).unregisterGlobalErrorCallback(any(OnErrorCallback.class));
   }
 
-  private RosiePresenter givenARosiePresenter() {
-    return new RosiePresenter(useCaseHandler);
+  private RosiePresenter givenARosiePresenterWithRegisteredCallback() {
+    return new RosiePresenterWithRegisteredCallback(useCaseHandler);
+  }
+
+  private static class RosiePresenterWithRegisteredCallback extends RosiePresenter
+      implements OnErrorCallback {
+    public RosiePresenterWithRegisteredCallback(UseCaseHandler useCaseHandler) {
+      super(useCaseHandler);
+      registerOnErrorCallback(this);
+    }
+
+    @Override public boolean onError(Error error) {
+      return true;
+    }
   }
 }


### PR DESCRIPTION
- Move all error handling to the `ErrorHandler` class instead of having it spread all over the use cases.
- Error bubbling system to start notifying error listeners starting from the more specific to the generic/presenter ones.
