### PR TITLE
Disable doc lint.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,3 +41,11 @@ allprojects {
     classpath = files()
   }
 }
+
+if (JavaVersion.current().isJava8Compatible()) {
+  allprojects {
+    tasks.withType(Javadoc) {
+      options.addStringOption('Xdoclint:none', '-quiet')
+    }
+  }
+}


### PR DESCRIPTION
As we are not using doc lint and we need to build the app executing `./gradlew build` I've decided to add a new rule to the `build.gradle` file to disable the javadoc lint.
