### PR TITLE
Improve ``PresenterLifeCycleLinker`` public API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ public class SampleApplication extends RosieApplication {
 }
 ```
 
-**Extend from ``RosieApplication`` is needed to be able to easily use the configuration Rosie provides you related to Dependency Injection. If you do not want to use Dependency Injection in your project, you do not need to extend from ``RosieApplication``.**
+**Extending from ``RosieApplication`` is needed to be able to easily use the configuration Rosie provides you related to Dependency Injection. If you do not want to use Dependency Injection in your project, you do not need to extend from ``RosieApplication``.**
 
 
 Rosie provides several base classes to start implementing your architecture separated in three layers, **view**, **domain** and **repository**. Let's explore them in detail.
@@ -51,7 +51,7 @@ public class SampleActivity extends RosieActivity {
 }
 ```
 
-**Extend from ``RosieActivity`` or ``RosieFragment`` is not mandatory. If your project is already extending from any other base Activity please review the class ``PresenterLifeCycleLinker`` and use it inside your base Activity or your Activities as follow:**
+**Extending from ``RosieActivity`` or ``RosieFragment`` is not mandatory. If your project is already extending from any other base Activity please review the class ``PresenterLifeCycleLinker`` and use it inside your base Activity or your Activities as follow:**
 
 ```java
 public abstract class MyBaseActivity extends FragmentActivity

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ public class SampleApplication extends RosieApplication {
 }
 ```
 
+**Extend from ``RosieApplication`` is needed to be able to easily use the configuration Rosie provides you related to Dependency Injection. If you do not want to use Dependency Injection in your project, you do not need to extend from ``RosieApplication``.**
+
 
 Rosie provides several base classes to start implementing your architecture separated in three layers, **view**, **domain** and **repository**. Let's explore them in detail.
 
@@ -48,6 +50,42 @@ public class SampleActivity extends RosieActivity {
 	/*...*/
 }
 ```
+
+**Extend from ``RosieActivity`` or ``RosieFragment`` is not mandatory. If your project is already extending from any other base Activity please review the class ``PresenterLifeCycleLinker`` and use it inside your base Activity or your Activities as follow:**
+
+```java
+public abstract class MyBaseActivity extends FragmentActivity
+    implements RosiePresenter.View {
+
+  private PresenterLifeCycleLinker presenterLifeCycleLinker = new PresenterLifeCycleLinker();
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    ...
+    presenterLifeCycleLinker.initializeLifeCycle(this, this);
+    ...
+  }
+  @Override protected void onResume() {
+    ...
+    presenterLifeCycleLinker.updatePresenters(this);
+    ...
+  }
+
+  @Override protected void onPause() {
+    ...
+    presenterLifeCycleLinker.pausePresenters();
+    ...
+  }
+
+  @Override protected void onDestroy() {
+    ...
+    super.onDestroy();
+    ...
+  }
+
+}
+```
+
+Rosie provides you some base classes to be extended and give you a quick access to the Dependency Injection and Model View Presenter features, but the usage of inheritance to use these features is not mandatory.
 
 ####Butter Knife
 

--- a/rosie/src/main/java/com/karumi/rosie/view/PresenterLifeCycleLinker.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/PresenterLifeCycleLinker.java
@@ -29,6 +29,13 @@ public final class PresenterLifeCycleLinker {
 
   private final Set<RosiePresenter> presenters = new HashSet<>();
 
+  /**
+   * Obtains all the presenter instances declared in the source param, configures the associated
+   * view and initializes the presenters lifecycle.
+   *
+   * @param source used to obtain the presenter references.
+   * @param view to be configured as presenters view.
+   */
   public void initializeLifeCycle(Object source, RosiePresenter.View view) {
     if (source == null) {
       throw new IllegalArgumentException(
@@ -44,12 +51,21 @@ public final class PresenterLifeCycleLinker {
     initializePresenters();
   }
 
+  /**
+   * Initializes all the already registered presenters lifecycle.
+   */
   public void initializePresenters() {
     for (RosiePresenter presenter : presenters) {
       presenter.initialize();
     }
   }
 
+  /**
+   * Updates all the already registered presenters lifecycle and updates the view instance
+   * associated to these presenters.
+   *
+   * @param view to be updated for every registered presenter.
+   */
   public void updatePresenters(RosiePresenter.View view) {
     if (view == null) {
       throw new IllegalArgumentException(
@@ -61,6 +77,9 @@ public final class PresenterLifeCycleLinker {
     }
   }
 
+  /**
+   * Pauses all the already registered presenters lifecycle.
+   */
   public void pausePresenters() {
     for (RosiePresenter presenter : presenters) {
       presenter.pause();
@@ -68,12 +87,20 @@ public final class PresenterLifeCycleLinker {
     }
   }
 
+  /**
+   * Destroys all the already registered presenters lifecycle.
+   */
   public void destroyPresenters() {
     for (RosiePresenter presenter : presenters) {
       presenter.destroy();
     }
   }
 
+  /**
+   * Registers a presenter instance.
+   *
+   * @param presenter to be registered
+   */
   public void registerPresenter(RosiePresenter presenter) {
     if (presenter == null) {
       throw new IllegalArgumentException("The presenter instance to be registered can't be null");
@@ -81,6 +108,11 @@ public final class PresenterLifeCycleLinker {
     presenters.add(presenter);
   }
 
+  /**
+   * Updates the view instance associated to all the already registered presenters.
+   *
+   * @param view to be assigned to the presenters.
+   */
   public void setView(RosiePresenter.View view) {
     if (view == null) {
       throw new IllegalArgumentException(

--- a/rosie/src/main/java/com/karumi/rosie/view/PresenterLifeCycleLinker.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/PresenterLifeCycleLinker.java
@@ -42,8 +42,8 @@ public final class PresenterLifeCycleLinker {
   }
 
   public void updatePresenters(RosiePresenter.View view) {
-    setView(view);
     for (RosiePresenter presenter : presenters) {
+      presenter.setView(view);
       presenter.update();
     }
   }
@@ -75,7 +75,7 @@ public final class PresenterLifeCycleLinker {
     for (Field field : source.getClass().getDeclaredFields()) {
       if (field.isAnnotationPresent(Presenter.class)) {
         if (Modifier.isPrivate(field.getModifiers())) {
-          throw new RuntimeException(
+          throw new PresenterNotAccessibleException(
               "Presenter must be accessible for this class. The visibility modifier used can't be"
                   + " private");
         } else {
@@ -85,14 +85,13 @@ public final class PresenterLifeCycleLinker {
             registerPresenter(presenter);
             field.setAccessible(false);
           } catch (IllegalAccessException e) {
-            IllegalStateException runtimeException = new IllegalStateException(
-                "the presenter " + field.getName() + " can not be access");
-            runtimeException.initCause(e);
-            throw runtimeException;
+            PresenterNotAccessibleException exception = new PresenterNotAccessibleException(
+                "the presenter " + field.getName() + " can not be accessed");
+            exception.initCause(e);
+            throw exception;
           }
         }
       }
     }
   }
-
 }

--- a/rosie/src/main/java/com/karumi/rosie/view/PresenterLifeCycleLinker.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/PresenterLifeCycleLinker.java
@@ -30,6 +30,15 @@ public final class PresenterLifeCycleLinker {
   private final Set<RosiePresenter> presenters = new HashSet<>();
 
   public void initializeLifeCycle(Object source, RosiePresenter.View view) {
+    if (source == null) {
+      throw new IllegalArgumentException(
+          "The source instance used to initialize the presenters can't be null");
+    }
+    if (view == null) {
+      throw new IllegalArgumentException(
+          "The view instance used to initialize the presenters can't be null");
+    }
+
     addAnnotatedPresenter(source);
     setView(view);
     initializePresenters();
@@ -42,6 +51,10 @@ public final class PresenterLifeCycleLinker {
   }
 
   public void updatePresenters(RosiePresenter.View view) {
+    if (view == null) {
+      throw new IllegalArgumentException(
+          "The view instance used to update the presenters can't be null");
+    }
     for (RosiePresenter presenter : presenters) {
       presenter.setView(view);
       presenter.update();
@@ -62,10 +75,17 @@ public final class PresenterLifeCycleLinker {
   }
 
   public void registerPresenter(RosiePresenter presenter) {
+    if (presenter == null) {
+      throw new IllegalArgumentException("The presenter instance to be registered can't be null");
+    }
     presenters.add(presenter);
   }
 
   public void setView(RosiePresenter.View view) {
+    if (view == null) {
+      throw new IllegalArgumentException(
+          "The view instance used to configure the presenters can't be null");
+    }
     for (RosiePresenter presenter : presenters) {
       presenter.setView(view);
     }

--- a/rosie/src/main/java/com/karumi/rosie/view/PresenterLifeCycleLinker.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/PresenterLifeCycleLinker.java
@@ -29,8 +29,8 @@ public final class PresenterLifeCycleLinker {
 
   private final Set<RosiePresenter> presenters = new HashSet<>();
 
-  public void addAnnotatedPresenter(Field[] declaredFields, Object source) {
-    for (Field field : declaredFields) {
+  public void addAnnotatedPresenter(Object source) {
+    for (Field field : source.getClass().getDeclaredFields()) {
       if (field.isAnnotationPresent(Presenter.class)) {
         if (Modifier.isPrivate(field.getModifiers())) {
           throw new RuntimeException(

--- a/rosie/src/main/java/com/karumi/rosie/view/PresenterNotAccessibleException.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/PresenterNotAccessibleException.java
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-package com.karumi.rosie.doubles;
+package com.karumi.rosie.view;
 
-import com.karumi.rosie.view.Presenter;
-import com.karumi.rosie.view.RosiePresenter;
+public class PresenterNotAccessibleException extends RuntimeException {
 
-public class AnyClassWithAnAnnotatedPresenter {
-
-  @Presenter public RosiePresenter<RosiePresenter.View> presenter;
-
+  public PresenterNotAccessibleException(String detailMessage) {
+    super(detailMessage);
+  }
 }

--- a/rosie/src/main/java/com/karumi/rosie/view/RosieActivity.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/RosieActivity.java
@@ -47,7 +47,7 @@ public abstract class RosieActivity extends FragmentActivity implements RosiePre
     int layoutId = getLayoutId();
     setContentView(layoutId);
     presenterLifeCycleLinker = new PresenterLifeCycleLinker();
-    presenterLifeCycleLinker.addAnnotatedPresenter(getClass().getDeclaredFields(), this);
+    presenterLifeCycleLinker.addAnnotatedPresenter(this);
     ButterKnife.bind(this);
     presenterLifeCycleLinker.setView(this);
     onPreparePresenter();

--- a/rosie/src/main/java/com/karumi/rosie/view/RosieActivity.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/RosieActivity.java
@@ -30,10 +30,11 @@ import java.util.List;
  * library. All activities in this project should extend from this one to be able to use core
  * features like view injection, dependency injection or Rosie presenters.
  */
-public abstract class RosieActivity extends FragmentActivity implements RosiePresenter.View, Injectable {
+public abstract class RosieActivity extends FragmentActivity
+    implements RosiePresenter.View, Injectable {
 
   private ObjectGraph activityScopeGraph;
-  private PresenterLifeCycleLinker presenterLifeCycleLinker;
+  private PresenterLifeCycleLinker presenterLifeCycleLinker = new PresenterLifeCycleLinker();
 
   /**
    * Initializes the object graph associated to the activity scope, links presenters to the
@@ -46,12 +47,9 @@ public abstract class RosieActivity extends FragmentActivity implements RosiePre
     }
     int layoutId = getLayoutId();
     setContentView(layoutId);
-    presenterLifeCycleLinker = new PresenterLifeCycleLinker();
-    presenterLifeCycleLinker.addAnnotatedPresenter(this);
     ButterKnife.bind(this);
-    presenterLifeCycleLinker.setView(this);
     onPreparePresenter();
-    presenterLifeCycleLinker.initializePresenters();
+    presenterLifeCycleLinker.initializeLifeCycle(this, this);
   }
 
   /**
@@ -67,8 +65,7 @@ public abstract class RosieActivity extends FragmentActivity implements RosiePre
    */
   @Override protected void onResume() {
     super.onResume();
-    presenterLifeCycleLinker.setView(this);
-    presenterLifeCycleLinker.updatePresenters();
+    presenterLifeCycleLinker.updatePresenters(this);
   }
 
   /**
@@ -91,8 +88,7 @@ public abstract class RosieActivity extends FragmentActivity implements RosiePre
    * Given an object passed as argument uses the object graph associated to the Activity scope
    * to resolve all the dependencies needed by the object and inject them.
    */
-  @Override
-  public final void inject(Object object) {
+  @Override public final void inject(Object object) {
     if (shouldInitializeActivityScopeGraph()) {
       injectActivityModules();
     }
@@ -123,7 +119,7 @@ public abstract class RosieActivity extends FragmentActivity implements RosiePre
   }
 
   /**
-   * Registers a presenter to link to this activity
+   * Registers a presenter to link to this activity.
    */
   protected final void registerPresenter(RosiePresenter presenter) {
     presenterLifeCycleLinker.registerPresenter(presenter);

--- a/rosie/src/main/java/com/karumi/rosie/view/RosieAppCompatActivity.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/RosieAppCompatActivity.java
@@ -50,7 +50,7 @@ public abstract class RosieAppCompatActivity extends AppCompatActivity implement
     int layoutId = getLayoutId();
     setContentView(layoutId);
     presenterLifeCycleLinker = new PresenterLifeCycleLinker();
-    presenterLifeCycleLinker.addAnnotatedPresenter(getClass().getDeclaredFields(), this);
+    presenterLifeCycleLinker.addAnnotatedPresenter(this);
     ButterKnife.bind(this);
     presenterLifeCycleLinker.setView(this);
     onPreparePresenter();

--- a/rosie/src/main/java/com/karumi/rosie/view/RosieAppCompatActivity.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/RosieAppCompatActivity.java
@@ -18,25 +18,23 @@ package com.karumi.rosie.view;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-
+import butterknife.ButterKnife;
 import com.karumi.rosie.application.RosieApplication;
 import com.karumi.rosie.module.RosieActivityModule;
-
+import dagger.ObjectGraph;
 import java.util.ArrayList;
 import java.util.List;
-
-import butterknife.ButterKnife;
-import dagger.ObjectGraph;
 
 /**
  * Base Activity created to implement some common functionality for every Activity using this
  * library. All activities in this project should extend from this one to be able to use core
  * features like view injection, dependency injection or Rosie presenters.
  */
-public abstract class RosieAppCompatActivity extends AppCompatActivity implements RosiePresenter.View, Injectable {
+public abstract class RosieAppCompatActivity extends AppCompatActivity
+    implements RosiePresenter.View, Injectable {
 
   private ObjectGraph activityScopeGraph;
-  private PresenterLifeCycleLinker presenterLifeCycleLinker;
+  private PresenterLifeCycleLinker presenterLifeCycleLinker = new PresenterLifeCycleLinker();
 
   /**
    * Initializes the object graph associated to the activity scope, links presenters to the
@@ -49,12 +47,9 @@ public abstract class RosieAppCompatActivity extends AppCompatActivity implement
     }
     int layoutId = getLayoutId();
     setContentView(layoutId);
-    presenterLifeCycleLinker = new PresenterLifeCycleLinker();
-    presenterLifeCycleLinker.addAnnotatedPresenter(this);
     ButterKnife.bind(this);
-    presenterLifeCycleLinker.setView(this);
     onPreparePresenter();
-    presenterLifeCycleLinker.initializePresenters();
+    presenterLifeCycleLinker.initializeLifeCycle(this, this);
   }
 
   /**
@@ -70,8 +65,7 @@ public abstract class RosieAppCompatActivity extends AppCompatActivity implement
    */
   @Override protected void onResume() {
     super.onResume();
-    presenterLifeCycleLinker.setView(this);
-    presenterLifeCycleLinker.updatePresenters();
+    presenterLifeCycleLinker.updatePresenters(this);
   }
 
   /**
@@ -94,8 +88,7 @@ public abstract class RosieAppCompatActivity extends AppCompatActivity implement
    * Given an object passed as argument uses the object graph associated to the Activity scope
    * to resolve all the dependencies needed by the object and inject them.
    */
-  @Override
-  public final void inject(Object object) {
+  @Override public final void inject(Object object) {
     if (shouldInitializeActivityScopeGraph()) {
       injectActivityModules();
     }
@@ -125,15 +118,15 @@ public abstract class RosieAppCompatActivity extends AppCompatActivity implement
     return new ArrayList<>();
   }
 
+  private boolean shouldInitializeActivityScopeGraph() {
+    return activityScopeGraph == null;
+  }
+
   /**
-   * Registers a presenter to link to this activity
+   * Registers a presenter to link to this activity.
    */
   protected final void registerPresenter(RosiePresenter presenter) {
     presenterLifeCycleLinker.registerPresenter(presenter);
-  }
-
-  private boolean shouldInitializeActivityScopeGraph() {
-    return activityScopeGraph == null;
   }
 
   private void injectActivityModules() {

--- a/rosie/src/main/java/com/karumi/rosie/view/RosieFragment.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/RosieFragment.java
@@ -67,7 +67,7 @@ public abstract class RosieFragment extends Fragment implements RosiePresenter.V
    */
   @Override public void onViewCreated(View view, Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
-    presenterLifeCycleLinker.addAnnotatedPresenter(getClass().getDeclaredFields(), this);
+    presenterLifeCycleLinker.addAnnotatedPresenter(this);
     presenterLifeCycleLinker.setView(this);
     onPreparePresenter();
     presenterLifeCycleLinker.initializePresenters();

--- a/rosie/src/main/java/com/karumi/rosie/view/RosieFragment.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/RosieFragment.java
@@ -63,14 +63,12 @@ public abstract class RosieFragment extends Fragment implements RosiePresenter.V
   }
 
   /**
-   * Injects the Fragment views using Butter Knife library.
+   * Injects the Fragment views using Butter Knife library and initializes the presenter lifecycle.
    */
   @Override public void onViewCreated(View view, Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
-    presenterLifeCycleLinker.addAnnotatedPresenter(this);
-    presenterLifeCycleLinker.setView(this);
     onPreparePresenter();
-    presenterLifeCycleLinker.initializePresenters();
+    presenterLifeCycleLinker.initializeLifeCycle(this, this);
   }
 
   /**
@@ -82,16 +80,15 @@ public abstract class RosieFragment extends Fragment implements RosiePresenter.V
   }
 
   /**
-   * Connects the Fragment onResume method with the presenter used in this Activity.
+   * Connects the Fragment onResume method with the presenters associated to the fragment.
    */
   @Override public void onResume() {
     super.onResume();
-    presenterLifeCycleLinker.setView(this);
-    presenterLifeCycleLinker.updatePresenters();
+    presenterLifeCycleLinker.updatePresenters(this);
   }
 
   /**
-   * Connects the Fragment onPause method with the presenter used in this Activity.
+   * Connects the Fragment onPause method with the presenters associated to the fragment.
    */
   @Override public void onPause() {
     super.onPause();
@@ -99,7 +96,7 @@ public abstract class RosieFragment extends Fragment implements RosiePresenter.V
   }
 
   /**
-   * Connects the Fragment onDestroy method with the presenter used in this Activity.
+   * Connects the Fragment onDestroy method with the presenters associated to the fragment.
    */
   @Override public void onDestroy() {
     super.onDestroy();
@@ -115,12 +112,12 @@ public abstract class RosieFragment extends Fragment implements RosiePresenter.V
   }
 
   /**
-   * Returns the layout id associated to the layout used in the activity.
+   * Returns the layout id associated to the layout used in the fragment.
    */
   protected abstract int getLayoutId();
 
   /**
-   * Registers a presenter to link to this activity
+   * Registers a presenter to link to this fragment.
    */
   protected final void registerPresenter(RosiePresenter presenter) {
     presenterLifeCycleLinker.registerPresenter(presenter);

--- a/rosie/src/test/java/com/karumi/rosie/doubles/AnyClassWithAPrivatePresenterAnnotated.java
+++ b/rosie/src/test/java/com/karumi/rosie/doubles/AnyClassWithAPrivatePresenterAnnotated.java
@@ -19,8 +19,7 @@ package com.karumi.rosie.doubles;
 import com.karumi.rosie.view.Presenter;
 import com.karumi.rosie.view.RosiePresenter;
 
-public class AnyClassWithAnAnnotatedPresenter {
+public class AnyClassWithAPrivatePresenterAnnotated {
 
-  @Presenter public RosiePresenter<RosiePresenter.View> presenter;
-
+  @Presenter private RosiePresenter<RosiePresenter.View> presenter;
 }

--- a/rosie/src/test/java/com/karumi/rosie/doubles/AnyClassWithAnAnnotatedPresenter.java
+++ b/rosie/src/test/java/com/karumi/rosie/doubles/AnyClassWithAnAnnotatedPresenter.java
@@ -1,0 +1,10 @@
+package com.karumi.rosie.doubles;
+
+import com.karumi.rosie.view.Presenter;
+import com.karumi.rosie.view.RosiePresenter;
+
+public class AnyClassWithAnAnnotatedPresenter {
+
+  @Presenter public RosiePresenter<RosiePresenter.View> presenter;
+
+}

--- a/rosie/src/test/java/com/karumi/rosie/view/PresenterLifeCycleLinkerTest.java
+++ b/rosie/src/test/java/com/karumi/rosie/view/PresenterLifeCycleLinkerTest.java
@@ -27,6 +27,7 @@ public class PresenterLifeCycleLinkerTest extends UnitTest {
 
   @Mock RosiePresenter anyPresenter1;
   @Mock RosiePresenter anyPresenter2;
+  @Mock RosiePresenter.View anyView;
 
   @Test public void shouldCallAllRegisteredPresentersAreCalledWhenInitializeIsCalled() {
     PresenterLifeCycleLinker presenterLifeCycleLinker =
@@ -42,7 +43,7 @@ public class PresenterLifeCycleLinkerTest extends UnitTest {
     PresenterLifeCycleLinker presenterLifeCycleLinker =
         givenAPresenterLifecycleLinker(anyPresenter1, anyPresenter2);
 
-    presenterLifeCycleLinker.updatePresenters();
+    presenterLifeCycleLinker.updatePresenters(anyView);
 
     verify(anyPresenter1).update();
     verify(anyPresenter2).update();
@@ -68,15 +69,26 @@ public class PresenterLifeCycleLinkerTest extends UnitTest {
     verify(anyPresenter2).pause();
   }
 
-  @Test public void shouldConfigureViewToEveryPresenterRegistered() {
+  @Test public void shouldConfigureViewToEveryPresenterRegisteredOnUpdatePresenters() {
     PresenterLifeCycleLinker presenterLifeCycleLinker =
         givenAPresenterLifecycleLinker(anyPresenter1, anyPresenter2);
 
-    RosiePresenter.View view = mock(RosiePresenter.View.class);
-    presenterLifeCycleLinker.setView(view);
 
-    verify(anyPresenter1).setView(view);
-    verify(anyPresenter2).setView(view);
+    presenterLifeCycleLinker.updatePresenters(anyView);
+
+    verify(anyPresenter1).setView(anyView);
+    verify(anyPresenter2).setView(anyView);
+  }
+
+  @Test public void shouldConfigureViewToEveryPresenterRegisteredOnSetView() {
+    PresenterLifeCycleLinker presenterLifeCycleLinker =
+        givenAPresenterLifecycleLinker(anyPresenter1, anyPresenter2);
+
+
+    presenterLifeCycleLinker.setView(anyView);
+
+    verify(anyPresenter1).setView(anyView);
+    verify(anyPresenter2).setView(anyView);
   }
 
   @Test public void shouldResetPresenterViewOnPause() {
@@ -84,7 +96,7 @@ public class PresenterLifeCycleLinkerTest extends UnitTest {
         givenAPresenterLifecycleLinker(anyPresenter1);
 
     presenterLifeCycleLinker.initializePresenters();
-    presenterLifeCycleLinker.updatePresenters();
+    presenterLifeCycleLinker.updatePresenters(anyView);
     presenterLifeCycleLinker.pausePresenters();
 
     verify(anyPresenter1).resetView();

--- a/rosie/src/test/java/com/karumi/rosie/view/PresenterLifeCycleLinkerTest.java
+++ b/rosie/src/test/java/com/karumi/rosie/view/PresenterLifeCycleLinkerTest.java
@@ -17,6 +17,7 @@
 package com.karumi.rosie.view;
 
 import com.karumi.rosie.UnitTest;
+import com.karumi.rosie.doubles.AnyClassWithAPrivatePresenterAnnotated;
 import com.karumi.rosie.doubles.AnyClassWithAnAnnotatedPresenter;
 import com.karumi.rosie.doubles.FakePresenter;
 import org.junit.Test;
@@ -107,6 +108,14 @@ public class PresenterLifeCycleLinkerTest extends UnitTest {
     presenterLifeCycleLinker.pausePresenters();
 
     assertNotEquals(anyView, presenter.getView());
+  }
+
+  @Test(expected = PresenterNotAccessibleException.class)
+  public void shouldThrowExceptionIfThereAnnotatedPresenterVisibilityIsPrivate() {
+    AnyClassWithAPrivatePresenterAnnotated source = new AnyClassWithAPrivatePresenterAnnotated();
+    PresenterLifeCycleLinker presenterLifeCycleLinker = givenAPresenterLifecycleLinker();
+
+    presenterLifeCycleLinker.initializeLifeCycle(source, anyView);
   }
 
   private PresenterLifeCycleLinker givenAPresenterLifecycleLinker(RosiePresenter... presenters) {

--- a/rosie/src/test/java/com/karumi/rosie/view/PresenterLifeCycleLinkerTest.java
+++ b/rosie/src/test/java/com/karumi/rosie/view/PresenterLifeCycleLinkerTest.java
@@ -118,6 +118,35 @@ public class PresenterLifeCycleLinkerTest extends UnitTest {
     presenterLifeCycleLinker.initializeLifeCycle(source, anyView);
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldNotAcceptNullSourcesToInitializeTheLifeCycle() {
+    PresenterLifeCycleLinker presenterLifeCycleLinker = givenAPresenterLifecycleLinker();
+
+    presenterLifeCycleLinker.initializeLifeCycle(null, anyView);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldNotAcceptNullViewsToInitializeTheLifeCycle() {
+    PresenterLifeCycleLinker presenterLifeCycleLinker = givenAPresenterLifecycleLinker();
+    Object source = givenAnyClassWithAnAnnotatedPresenter(anyPresenter1);
+
+    presenterLifeCycleLinker.initializeLifeCycle(source, null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldNotAcceptNullViewsToConfigureThePresenters() {
+    PresenterLifeCycleLinker presenterLifeCycleLinker = givenAPresenterLifecycleLinker();
+
+    presenterLifeCycleLinker.setView(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldNotAcceptNullPresentersToRegister() {
+    PresenterLifeCycleLinker presenterLifeCycleLinker = givenAPresenterLifecycleLinker();
+
+    presenterLifeCycleLinker.registerPresenter(null);
+  }
+
   private PresenterLifeCycleLinker givenAPresenterLifecycleLinker(RosiePresenter... presenters) {
     PresenterLifeCycleLinker presenterLifeCycleLinker = new PresenterLifeCycleLinker();
     for (RosiePresenter presenter : presenters) {

--- a/rosie/src/test/java/com/karumi/rosie/view/PresenterLifeCycleLinkerTest.java
+++ b/rosie/src/test/java/com/karumi/rosie/view/PresenterLifeCycleLinkerTest.java
@@ -4,23 +4,26 @@
  * "Software"), to deal in the Software without restriction, including without limitation the
  * rights to use, copy, modify, merge, publish, distribute, sublicense,
  * and/or sell copies of the Software, and to permit persons to whom the Software is furnished to
-  * do so, subject to the following conditions: The above copyright notice and this permission
-  * notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE
-  * IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
-  * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-  * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-  * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * do so, subject to the following conditions: The above copyright notice and this permission
+ * notice shall be included in all copies or substantial portions of the Software. THE SOFTWARE
+ * IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 package com.karumi.rosie.view;
 
 import com.karumi.rosie.UnitTest;
+import com.karumi.rosie.doubles.AnyClassWithAnAnnotatedPresenter;
+import com.karumi.rosie.doubles.FakePresenter;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.verify;
 
 public class PresenterLifeCycleLinkerTest extends UnitTest {
@@ -28,6 +31,15 @@ public class PresenterLifeCycleLinkerTest extends UnitTest {
   @Mock RosiePresenter anyPresenter1;
   @Mock RosiePresenter anyPresenter2;
   @Mock RosiePresenter.View anyView;
+
+  @Test public void shouldInitializePresentersLifecycleOnInitializeLifecycleIsCalled() {
+    PresenterLifeCycleLinker presenterLifeCycleLinker = givenAPresenterLifecycleLinker();
+    Object source = givenAnyClassWithAnAnnotatedPresenter(anyPresenter1);
+
+    presenterLifeCycleLinker.initializeLifeCycle(source, anyView);
+
+    verify(anyPresenter1).initialize();
+  }
 
   @Test public void shouldCallAllRegisteredPresentersAreCalledWhenInitializeIsCalled() {
     PresenterLifeCycleLinker presenterLifeCycleLinker =
@@ -69,37 +81,32 @@ public class PresenterLifeCycleLinkerTest extends UnitTest {
     verify(anyPresenter2).pause();
   }
 
-  @Test public void shouldConfigureViewToEveryPresenterRegisteredOnUpdatePresenters() {
-    PresenterLifeCycleLinker presenterLifeCycleLinker =
-        givenAPresenterLifecycleLinker(anyPresenter1, anyPresenter2);
-
+  @Test public void shouldUpdateThePresentersViewWhenUpdateIsCalled() {
+    RosiePresenter presenter = givenAnyPresenter();
+    PresenterLifeCycleLinker presenterLifeCycleLinker = givenAPresenterLifecycleLinker(presenter);
 
     presenterLifeCycleLinker.updatePresenters(anyView);
 
-    verify(anyPresenter1).setView(anyView);
-    verify(anyPresenter2).setView(anyView);
+    assertEquals(anyView, presenter.getView());
   }
 
-  @Test public void shouldConfigureViewToEveryPresenterRegisteredOnSetView() {
-    PresenterLifeCycleLinker presenterLifeCycleLinker =
-        givenAPresenterLifecycleLinker(anyPresenter1, anyPresenter2);
-
+  @Test public void shouldUpdateThePresentersViewWhenSetViewIsCalled() {
+    RosiePresenter presenter = givenAnyPresenter();
+    PresenterLifeCycleLinker presenterLifeCycleLinker = givenAPresenterLifecycleLinker(presenter);
 
     presenterLifeCycleLinker.setView(anyView);
 
-    verify(anyPresenter1).setView(anyView);
-    verify(anyPresenter2).setView(anyView);
+    assertEquals(anyView, presenter.getView());
   }
 
   @Test public void shouldResetPresenterViewOnPause() {
-    PresenterLifeCycleLinker presenterLifeCycleLinker =
-        givenAPresenterLifecycleLinker(anyPresenter1);
+    RosiePresenter presenter = givenAnyPresenter();
+    PresenterLifeCycleLinker presenterLifeCycleLinker = givenAPresenterLifecycleLinker(presenter);
 
-    presenterLifeCycleLinker.initializePresenters();
     presenterLifeCycleLinker.updatePresenters(anyView);
     presenterLifeCycleLinker.pausePresenters();
 
-    verify(anyPresenter1).resetView();
+    assertNotEquals(anyView, presenter.getView());
   }
 
   private PresenterLifeCycleLinker givenAPresenterLifecycleLinker(RosiePresenter... presenters) {
@@ -108,5 +115,16 @@ public class PresenterLifeCycleLinkerTest extends UnitTest {
       presenterLifeCycleLinker.registerPresenter(presenter);
     }
     return presenterLifeCycleLinker;
+  }
+
+  private Object givenAnyClassWithAnAnnotatedPresenter(RosiePresenter presenter) {
+    AnyClassWithAnAnnotatedPresenter anyClassWithAnAnnotatedPresenter =
+        new AnyClassWithAnAnnotatedPresenter();
+    anyClassWithAnAnnotatedPresenter.presenter = presenter;
+    return anyClassWithAnAnnotatedPresenter;
+  }
+
+  private RosiePresenter givenAnyPresenter() {
+    return new FakePresenter();
   }
 }

--- a/rosie/src/test/java/com/karumi/rosie/view/PresenterLifeCycleLinkerTest.java
+++ b/rosie/src/test/java/com/karumi/rosie/view/PresenterLifeCycleLinkerTest.java
@@ -111,7 +111,7 @@ public class PresenterLifeCycleLinkerTest extends UnitTest {
   }
 
   @Test(expected = PresenterNotAccessibleException.class)
-  public void shouldThrowExceptionIfThereAnnotatedPresenterVisibilityIsPrivate() {
+  public void shouldThrowExceptionIfTheAnnotatedPresenterVisibilityIsPrivate() {
     AnyClassWithAPrivatePresenterAnnotated source = new AnyClassWithAPrivatePresenterAnnotated();
     PresenterLifeCycleLinker presenterLifeCycleLinker = givenAPresenterLifecycleLinker();
 


### PR DESCRIPTION
Fix #51. Now that we have accepted a pull request (#49) changing the visibility of the class ``PresenterLifeCycleLinker`` from default to public I have decided to improve this class usage. This is the list of improvements you will find in this pull request.

* Simplify the class usage reducing the number of methods needed to link the component lifecycle with the presenter lifecycle.
* Add javadoc.
* Add some guards related to the input params.
* Improve test coverage.
* Improve the project README to show how to use Rosie without extending from ``RosieActivity`` or ``RosieFragment``.
