### PR TITLE
Change presenter lifecycle and set view visibility to be public instead of default or protected.

### DIFF
--- a/rosie/src/main/java/com/karumi/rosie/view/RosiePresenter.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/RosiePresenter.java
@@ -47,7 +47,7 @@ public class RosiePresenter<T extends RosiePresenter.View> {
    * Method called in the presenter lifecycle. Invoked when the component containing the presenter
    * is initialized.
    */
-  protected void initialize() {
+  public void initialize() {
     registerGlobalErrorCallback();
   }
 
@@ -55,7 +55,7 @@ public class RosiePresenter<T extends RosiePresenter.View> {
    * Method called in the presenter lifecycle. Invoked when the component containing the presenter
    * is resumed.
    */
-  protected void update() {
+  public void update() {
     registerGlobalErrorCallback();
   }
 
@@ -63,7 +63,7 @@ public class RosiePresenter<T extends RosiePresenter.View> {
    * Method called in the presenter lifecycle. Invoked when the component containing the presenter
    * is paused.
    */
-  protected void pause() {
+  public void pause() {
     unregisterGlobalErrorCallback();
   }
 
@@ -71,7 +71,7 @@ public class RosiePresenter<T extends RosiePresenter.View> {
    * Method called in the presenter lifecycle. Invoked when the component containing the presenter
    * is destroyed.
    */
-  protected void destroy() {
+  public void destroy() {
     globalOnErrorCallbacks.clear();
   }
 
@@ -92,8 +92,15 @@ public class RosiePresenter<T extends RosiePresenter.View> {
    * Returns the view configured in the presenter which real implementation is an Activity or
    * Fragment using this presenter.
    */
-  protected final T getView() {
+  public final T getView() {
     return view;
+  }
+
+  /**
+   * Configures the View instance used in this presenter as view.
+   */
+  public void setView(T view) {
+    this.view = view;
   }
 
   /**
@@ -111,13 +118,6 @@ public class RosiePresenter<T extends RosiePresenter.View> {
    */
   protected void registerOnErrorCallback(OnErrorCallback onErrorCallback) {
     globalOnErrorCallbacks.add(onErrorCallback);
-  }
-
-  /**
-   * Configures the View instance used in this presenter as view.
-   */
-  void setView(T view) {
-    this.view = view;
   }
 
   /**

--- a/sample/src/main/java/com/karumi/rosie/sample/characters/view/presenter/CharacterDetailsPresenter.java
+++ b/sample/src/main/java/com/karumi/rosie/sample/characters/view/presenter/CharacterDetailsPresenter.java
@@ -41,7 +41,7 @@ public class CharacterDetailsPresenter
     this.getCharacterDetails = getCharacterDetails;
   }
 
-  @Override protected void update() {
+  @Override public void update() {
     super.update();
     showLoading();
     loadCharacterDetails();

--- a/sample/src/main/java/com/karumi/rosie/sample/characters/view/presenter/CharactersPresenter.java
+++ b/sample/src/main/java/com/karumi/rosie/sample/characters/view/presenter/CharactersPresenter.java
@@ -45,7 +45,7 @@ public class CharactersPresenter extends MarvelPresenter<CharactersPresenter.Vie
     this.mapper = mapper;
   }
 
-  @Override protected void update() {
+  @Override public void update() {
     super.update();
     getView().hideCharacters();
     showLoading();

--- a/sample/src/main/java/com/karumi/rosie/sample/comics/view/presenter/ComicSeriesDetailsPresenter.java
+++ b/sample/src/main/java/com/karumi/rosie/sample/comics/view/presenter/ComicSeriesDetailsPresenter.java
@@ -46,7 +46,7 @@ public class ComicSeriesDetailsPresenter
     this.comicSeriesKey = comicKey;
   }
 
-  @Override protected void update() {
+  @Override public void update() {
     super.update();
     showLoading();
     getView().hideComicSeriesDetails();

--- a/sample/src/main/java/com/karumi/rosie/sample/comics/view/presenter/ComicsSeriesPresenter.java
+++ b/sample/src/main/java/com/karumi/rosie/sample/comics/view/presenter/ComicsSeriesPresenter.java
@@ -44,7 +44,7 @@ public class ComicsSeriesPresenter extends RosiePresenterWithLoading<ComicsSerie
     this.getComicSeriesPage = getComicSeriesPage;
   }
 
-  @Override protected void update() {
+  @Override public void update() {
     super.update();
     getView().hideComicSeries();
     showLoading();

--- a/sample/src/main/java/com/karumi/rosie/sample/main/view/presenter/FakeDataPresenter.java
+++ b/sample/src/main/java/com/karumi/rosie/sample/main/view/presenter/FakeDataPresenter.java
@@ -32,7 +32,7 @@ public class FakeDataPresenter extends RosiePresenter<FakeDataPresenter.View> {
     this.getMarvelSettings = getMarvelSettings;
   }
 
-  @Override protected void initialize() {
+  @Override public void initialize() {
     super.initialize();
     if (!getMarvelSettings.haveKeys()) {
       getView().showFakeDisclaimer();


### PR DESCRIPTION
Fix #48. To be able to write a unit test of any presenter we need to change the presenter lifecycle visibility and all the methods related to the view. In this PR I change the visibility from protected or default to public.