### PR TITLE
Fix #59.

### DIFF
--- a/rosie/src/main/java/com/karumi/rosie/view/RosieActivity.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/RosieActivity.java
@@ -130,6 +130,9 @@ public abstract class RosieActivity extends FragmentActivity
   }
 
   private void injectActivityModules() {
+    if (!(getApplication() instanceof RosieApplication)) {
+      return;
+    }
     RosieApplication rosieApplication = (RosieApplication) getApplication();
     List<Object> additionalModules = getActivityScopeModules();
     if (additionalModules == null) {

--- a/rosie/src/main/java/com/karumi/rosie/view/RosieAppCompatActivity.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/RosieAppCompatActivity.java
@@ -130,6 +130,9 @@ public abstract class RosieAppCompatActivity extends AppCompatActivity
   }
 
   private void injectActivityModules() {
+    if (!(getApplication() instanceof RosieApplication)) {
+      return;
+    }
     RosieApplication rosieApplication = (RosieApplication) getApplication();
     List<Object> additionalModules = getActivityScopeModules();
     if (additionalModules == null) {


### PR DESCRIPTION
Add two guards to the points where ``RosieApplication`` is used to avoid a ``ClassCastException`` during the inject activity process.