### PR TITLE
New list in UseCaseHandler to retain error adapters in a non-weak reference

### DIFF
--- a/rosie/src/main/java/com/karumi/rosie/domain/usecase/UseCaseHandler.java
+++ b/rosie/src/main/java/com/karumi/rosie/domain/usecase/UseCaseHandler.java
@@ -19,6 +19,10 @@ package com.karumi.rosie.domain.usecase;
 import com.karumi.rosie.domain.usecase.error.ErrorHandler;
 import com.karumi.rosie.domain.usecase.error.OnErrorCallback;
 
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Invoke methods annotated with UseCase annotation. The RosieUseCase instance will be executed out
  * of the Android main thread and the result of the operation will be provided asynchronously using
@@ -29,9 +33,13 @@ public class UseCaseHandler {
   private final TaskScheduler taskScheduler;
   private final ErrorHandler errorHandler;
 
+  // This list is used to retain error adapters in a non-weak reference associated with this use case handler
+  private List<OnErrorCallbackToErrorHandlerAdapter> errorAdapters;
+
   public UseCaseHandler(TaskScheduler taskScheduler, ErrorHandler errorHandler) {
     this.taskScheduler = taskScheduler;
     this.errorHandler = errorHandler;
+    this.errorAdapters = new ArrayList<>();
   }
 
   /**
@@ -45,8 +53,12 @@ public class UseCaseHandler {
     UseCaseFilter.filter(useCase, useCaseParams);
 
     useCase.setOnSuccessCallback(useCaseParams.getOnSuccessCallback());
-    useCase.setOnErrorCallback(
-        new OnErrorCallbackToErrorHandlerAdapter(errorHandler, useCaseParams.getOnErrorCallback()));
+
+    OnErrorCallbackToErrorHandlerAdapter errorAdapter =
+        new OnErrorCallbackToErrorHandlerAdapter(errorHandler, useCaseParams.getOnErrorCallback());
+    errorAdapters.add(errorAdapter);
+    useCase.setOnErrorCallback(errorAdapter);
+
     UseCaseWrapper useCaseWrapper = new UseCaseWrapper(useCase, useCaseParams, errorHandler);
     taskScheduler.execute(useCaseWrapper);
   }
@@ -63,18 +75,21 @@ public class UseCaseHandler {
    * Inner class responsible for routing the errors thrown from the use case to the error handler
    */
   private static class OnErrorCallbackToErrorHandlerAdapter implements OnErrorCallback {
-    private final ErrorHandler errorHandler;
-    private final OnErrorCallback useCaseOnErrorCallback;
+    private WeakReference<ErrorHandler> errorHandler;
+    private WeakReference<OnErrorCallback> useCaseOnErrorCallback;
 
     public OnErrorCallbackToErrorHandlerAdapter(ErrorHandler errorHandler,
         OnErrorCallback useCaseOnErrorCallback) {
-      this.errorHandler = errorHandler;
-      this.useCaseOnErrorCallback = useCaseOnErrorCallback;
+      this.errorHandler = new WeakReference<>(errorHandler);
+      this.useCaseOnErrorCallback = new WeakReference<>(useCaseOnErrorCallback);
     }
 
     @Override public boolean onError(Error error) {
-      errorHandler.notifyError(error, useCaseOnErrorCallback);
-      return true;
+      if (errorHandler.get() != null) {
+        errorHandler.get().notifyError(error, useCaseOnErrorCallback.get());
+        return true;
+      }
+      return false;
     }
   }
 }

--- a/rosie/src/main/java/com/karumi/rosie/domain/usecase/UseCaseHandler.java
+++ b/rosie/src/main/java/com/karumi/rosie/domain/usecase/UseCaseHandler.java
@@ -85,8 +85,9 @@ public class UseCaseHandler {
     }
 
     @Override public boolean onError(Error error) {
-      if (errorHandler.get() != null) {
-        errorHandler.get().notifyError(error, useCaseOnErrorCallback.get());
+      ErrorHandler errorHandler = this.errorHandler.get();
+      if (errorHandler != null) {
+        errorHandler.notifyError(error, useCaseOnErrorCallback.get());
         return true;
       }
       return false;

--- a/rosie/src/main/java/com/karumi/rosie/domain/usecase/UseCaseHandler.java
+++ b/rosie/src/main/java/com/karumi/rosie/domain/usecase/UseCaseHandler.java
@@ -33,13 +33,13 @@ public class UseCaseHandler {
   private final TaskScheduler taskScheduler;
   private final ErrorHandler errorHandler;
 
-  // This list is used to retain error adapters in a non-weak reference associated with this use case handler
-  private List<OnErrorCallbackToErrorHandlerAdapter> errorAdapters;
+  // This list is used to retain error adapters in a non-weak reference associated with this use
+  // case handler
+  private final List<OnErrorCallback> errorCallbacks = new ArrayList<>();
 
   public UseCaseHandler(TaskScheduler taskScheduler, ErrorHandler errorHandler) {
     this.taskScheduler = taskScheduler;
     this.errorHandler = errorHandler;
-    this.errorAdapters = new ArrayList<>();
   }
 
   /**
@@ -54,10 +54,10 @@ public class UseCaseHandler {
 
     useCase.setOnSuccessCallback(useCaseParams.getOnSuccessCallback());
 
-    OnErrorCallbackToErrorHandlerAdapter errorAdapter =
+    OnErrorCallback onErrorCallback =
         new OnErrorCallbackToErrorHandlerAdapter(errorHandler, useCaseParams.getOnErrorCallback());
-    errorAdapters.add(errorAdapter);
-    useCase.setOnErrorCallback(errorAdapter);
+    errorCallbacks.add(onErrorCallback);
+    useCase.setOnErrorCallback(onErrorCallback);
 
     UseCaseWrapper useCaseWrapper = new UseCaseWrapper(useCase, useCaseParams, errorHandler);
     taskScheduler.execute(useCaseWrapper);
@@ -75,8 +75,8 @@ public class UseCaseHandler {
    * Inner class responsible for routing the errors thrown from the use case to the error handler
    */
   private static class OnErrorCallbackToErrorHandlerAdapter implements OnErrorCallback {
-    private WeakReference<ErrorHandler> errorHandler;
-    private WeakReference<OnErrorCallback> useCaseOnErrorCallback;
+    private final WeakReference<ErrorHandler> errorHandler;
+    private final WeakReference<OnErrorCallback> useCaseOnErrorCallback;
 
     public OnErrorCallbackToErrorHandlerAdapter(ErrorHandler errorHandler,
         OnErrorCallback useCaseOnErrorCallback) {


### PR DESCRIPTION
* This change solves a NullPointerException in RosieUseCase.notifyError that was happening when the error adapter was cleared of memory, because the adapter was only saved in a WeakReference in RosieUseCase
* Also, I am modifying OnErrorCallbackToErrorHandlerAdapter to save the constructor parameters in weak references
* I am using Rosie in an app available in Google Play, everything is working fine except for a few crashes caused by this error. I have solved this issue temporally replacing UseCaseHandler with my own class with these changes.

Thanks for this amazing framework