### PR TITLE
Update Travis-CI configuration to use the new image they recommended us.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: android
+dist: trusty
+sudo: required
+group: edge
 
 android:
   components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ android:
     - extra-android-support
     - extra-google-m2repository
     - extra-android-m2repository
-    - sys-img-armeabi-v7a-android-21
+    - sys-img-armeabi-v7a-android-22
 
 before_script:
-  - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell settings put global window_animation_scale 0 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ android:
     - sys-img-armeabi-v7a-android-22
 
 before_script:
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+  - echo no | android create avd --name test --package "system-images;android-22;default;armeabi-v7a"
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell settings put global window_animation_scale 0 &


### PR DESCRIPTION
As a bit more information, this new Android image comes with:
* Android SDK 25.2.3
* build-tools-25.0.2
* The new sdkmanager tool - a command line tool that allows you to view, install, update, and uninstall packages for the Android SDK. Replaces the previous android tool, see https://developer.android.com/studio/tools/help/android.html
* Also, the new Android image should be retro-compatible. See the full list of Android SDK components that can be specified in the .travis.yml file, including build-tools-26.0.0-preview.