### PR TITLE
Allowing to implement RosiePresenter.View interfaces in base Fragments or Activity classes

### DIFF
--- a/rosie/src/main/java/com/karumi/rosie/view/RosiePresenter.java
+++ b/rosie/src/main/java/com/karumi/rosie/view/RosiePresenter.java
@@ -146,8 +146,30 @@ public class RosiePresenter<T extends RosiePresenter.View> {
         interfaceClass = interfaceCandidate;
       }
     }
-    return interfaceClass;
+    if (interfaceClass != null) {
+      return interfaceClass;
+    } else {
+      return getViewInterfaceSuperClass(this.view.getClass());
+    }
   }
+
+  private Class<?> getViewInterfaceSuperClass(Class<?> currentClass) {
+    Class<?> interfaceClass = null;
+    Class<?> superClass = currentClass.getSuperclass();
+    Class<?>[] interfaces = superClass.getInterfaces();
+    for (int i = 0; i < interfaces.length; i++) {
+      Class<?> interfaceCandidate = interfaces[i];
+      if (RosiePresenter.View.class.isAssignableFrom(interfaceCandidate)) {
+        interfaceClass = interfaceCandidate;
+      }
+    }
+    if (interfaceClass != null) {
+      return interfaceClass;
+    } else {
+      return getViewInterfaceSuperClass(superClass);
+    }
+  }
+
 
   private void registerGlobalErrorCallback() {
     if (shouldRegisterGlobalErrorCallbacks) {


### PR DESCRIPTION
Hello guys! First of all thank you very much for Rosie. It has been very helpful in the project We are working on.

I tried to implement my View interface in a Base Fragment class and I realized that was not possible because in RosiePresenter.class getViewInterfaceClass method was not looking for interfaces in any available super classes. I added a method that is called inside getViewInterfaceClass for seeking any RosiePresenter.View interfaces in any super class available if there is no RosiePresenter.View interfaces in the current class.

PS: I ran the tests but I got this error while testing the app sample:
_android.support.test.espresso.NoMatchingViewException: No views in hierarchy found matching: (with id: com.karumi.rosie.sample:id/snackbar_text and with text..._

Thank you!